### PR TITLE
feat: get latest tag subdirectory

### DIFF
--- a/util/latest.rb
+++ b/util/latest.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+unless ARGV.length == 1
+  $stderr.puts """USAGE: #{$0} [SUBDIRECTORY]
+  - obtains the the latest tag from [SUBDIRECTORY], assuming [SUBDIRECTORY] 
+    contains subdirectories of tag names"""
+  exit 2
+end
+
+subdir = ARGV[0]
+unless Dir.exist? subdir
+  $stderr.puts "ERROR: subdirectory '#{subdir}' does not exist"
+  exit 1
+end
+
+tagdirs = Dir.glob("#{subdir}/*/")
+unless tagdirs.length > 0
+  $stderr.puts "ERROR: subdirectory '#{subdir}' has no subdirectories"
+  exit 1
+end
+
+puts tagdirs.map{ |v|
+  begin
+    Gem::Version.new File.basename(v)
+  rescue
+    Gem::Version.new '0.0.0'
+  end
+}.max


### PR DESCRIPTION
The config files in `gemc/` and `coatjava/` are organized by tag. The latest one may be obtained by, for example,
```bash
util/latest.rb coatjava
```
which returns
```
10.0.2
```
This uses semantic version number comparison to find the max, and ignores subdirectories that are not named semantic version numbers.