### PR TITLE
ci: trigger `clas12-validation`

### DIFF
--- a/.github/workflows/validation-dev.yml
+++ b/.github/workflows/validation-dev.yml
@@ -1,0 +1,22 @@
+name: Validation-dev
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+    tags: [ '*' ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  validation:
+    uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@main
+    with:
+      config_file_versions: >-
+        {
+          "coatjava": "latest",
+          "gemc":     "dev"
+        }

--- a/.github/workflows/validation-latest.yml
+++ b/.github/workflows/validation-latest.yml
@@ -1,0 +1,16 @@
+name: Validation-latest
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+    tags: [ '*' ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  validation:
+    uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@main


### PR DESCRIPTION
Add `clas12-validation` workflow trigger, the same as that in `coatjava`. Two workflows are added, one for the latest config file versions, and the other for the `dev` version.