### PR TITLE
fix: get the latest version of each config file

### DIFF
--- a/.github/ci_config_files.json
+++ b/.github/ci_config_files.json
@@ -1,0 +1,8 @@
+[
+  "clas12-default",
+  "rga_spring2018",
+  "rga_fall2018",
+  "rgk_fall2018_FTOn",
+  "rgb_fall2019",
+  "rgc_summer2022_FTOn"
+]

--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ The standard run-group configuration files for GEMC, COATJAVA, chef workflow con
 * _GEMC versions prior to 5.3 do not fully support binary magnetic field maps._
 * _GEMC versions prior to 5.4 do not support CCDB for RF configuration._
 * _COATJAVA versions prior to 9.0.1 do not support AI- denoising or track-finding._
+
+## Validation
+
+The default set of configuration files that is tested by [`clas12-validation`](https://www.github.com/JeffersonLab/clas12-validation) is [found here](.github/ci_config_files.json). The latest version of each configuration file is used, unless overridden by the caller workflow.

--- a/util/latest.rb
+++ b/util/latest.rb
@@ -1,28 +1,51 @@
 #!/usr/bin/env ruby
 
-unless ARGV.length == 1
-  $stderr.puts """USAGE: #{$0} [SUBDIRECTORY]
-  - obtains the the latest tag from [SUBDIRECTORY], assuming [SUBDIRECTORY] 
-    contains subdirectories of tag names"""
+unless ARGV.length == 2
+  $stderr.puts """USAGE: #{$0} [SUBDIRECTORY] [CONFIG_BASENAME]
+  - obtain the latest version of the config file with basename [CONFIG] from 
+    [SUBDIRECTORY], assuming [SUBDIRECTORY] contains subdirectories of tag names
+  - tag names that are not semantic version numbers, such as `dev`, are ignored
+  """
   exit 2
 end
 
-subdir = ARGV[0]
+subdir, config = ARGV
 unless Dir.exist? subdir
   $stderr.puts "ERROR: subdirectory '#{subdir}' does not exist"
   exit 1
 end
 
-tagdirs = Dir.glob("#{subdir}/*/")
-unless tagdirs.length > 0
-  $stderr.puts "ERROR: subdirectory '#{subdir}' has no subdirectories"
-  exit 1
-end
-
-puts tagdirs.map{ |v|
+# get list of tag subdirectories and sort them by semantic version number
+# - excludes directories which are not version numbers
+tagdirs = Dir.glob("#{subdir}/*/").map{ |v|
   begin
     Gem::Version.new File.basename(v)
   rescue
-    Gem::Version.new '0.0.0'
+    nil
   end
-}.max
+}
+  .compact
+  .sort
+  .reverse
+  .map &:to_s
+
+if tagdirs.empty?
+  $stderr.puts "ERROR: subdirectory '#{subdir}' has no subdirectories with semantic version numbers"
+  exit 1
+end
+
+# find the config files with the requested basename
+configFiles = tagdirs.map{ |v|
+  Dir.glob("#{subdir}/#{v}/*").find{ |f|
+    File.basename(f).match? /^#{config}\./
+  }
+}
+  .compact
+
+if configFiles.empty?
+  $stderr.puts "ERROR: cannot find config file with basename '#{config}' in any versioned subdirectory of '#{subdir}'"
+  exit 1
+end
+
+# return the latest version of that config file
+puts configFiles.first


### PR DESCRIPTION
- `util/latest.rb` now returns the latest version of a particular configuration file
- add `.github/ci_config_files.json`, the list of configuration files which we want to continuously test in `clas12-validation`

This should help protect us against the recent issue where the new `coatjava/10.0.4` directory lacks non RG-D configuration files (they are in previous `coatjava` version subdirectories).

Requires https://github.com/JeffersonLab/clas12-validation/pull/44