### PR TITLE
ci: remove validation caller concurrency class

### DIFF
--- a/.github/workflows/validation-dev.yml
+++ b/.github/workflows/validation-dev.yml
@@ -7,10 +7,6 @@ on:
     tags: [ '*' ]
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   validation:
     uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@main

--- a/.github/workflows/validation-latest.yml
+++ b/.github/workflows/validation-latest.yml
@@ -7,10 +7,6 @@ on:
     tags: [ '*' ]
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   validation:
     uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@main


### PR DESCRIPTION
- respect https://github.com/JeffersonLab/clas12-validation/pull/64
  - callers can't override the reusable workflow class, so this PR removes it