### PR TITLE
Added RGE configs to setup.json

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -239,5 +239,165 @@
 	"software_versions": [
 	  "gemc/5.10 coatjava/10.1.1"
         ]
+  },
+  "rge_spring2024_LD2-Al-sol": {
+	"tor-1.00_sol-1.00": [
+	],
+	"raster": [
+	  "0.0*cm, 0.0*cm"
+	],
+	"beam_spot": [
+	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
+	],
+	"z-position": [
+	  "-1.0*cm, 0.6*mm"
+	],
+	"software_versions": [
+	  "gemc/dev coatjava/10.1.1"
+        ]
+  },
+  "rge_spring2024_LD2-C-sol": {
+	"tor-1.00_sol-1.00": [
+	],
+	"raster": [
+	  "0.0*cm, 0.0*cm"
+	],
+	"beam_spot": [
+	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
+	],
+	"z-position": [
+	  "-1.0*cm, 0.74*mm"
+	],
+	"software_versions": [
+	  "gemc/dev coatjava/10.1.1"
+        ]
+  },
+  "rge_spring2024_LD2-Cu-sol": {
+	"tor-1.00_sol-1.00": [
+	],
+	"raster": [
+	  "0.0*cm, 0.0*cm"
+	],
+	"beam_spot": [
+	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
+	],
+	"z-position": [
+	  "-1.0*cm, 0.18*mm"
+	],
+	"software_versions": [
+	  "gemc/dev coatjava/10.1.1"
+        ]
+  },
+  "rge_spring2024_LD2-Sn-sol": {
+	"tor-1.00_sol-1.00": [
+	],
+	"raster": [
+	  "0.0*cm, 0.0*cm"
+	],
+	"beam_spot": [
+	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
+	],
+	"z-position": [
+	  "-1.0*cm, 0.15*mm"
+	],
+	"software_versions": [
+	  "gemc/dev coatjava/10.1.1"
+        ]
+  },
+  "rge_spring2024_LD2-Pb-sol": {
+	"tor-1.00_sol-1.00": [
+	],
+	"raster": [
+	  "0.0*cm, 0.0*cm"
+	],
+	"beam_spot": [
+	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
+	],
+	"z-position": [
+	  "-1.0*cm, 0.07*mm"
+	],
+	"software_versions": [
+	  "gemc/dev coatjava/10.1.1"
+        ]
+  },
+  "rge_spring2024_LD2-Al-liq": {
+	"tor-1.00_sol-1.00": [
+	],
+	"raster": [
+	  "0.0*cm, 0.0*cm"
+	],
+	"beam_spot": [
+	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
+	],
+	"z-position": [
+	  "-6.0*cm, 1.0*cm"
+	],
+	"software_versions": [
+	  "gemc/dev coatjava/10.1.1"
+        ]
+  },
+  "rge_spring2024_LD2-C-liq": {
+	"tor-1.00_sol-1.00": [
+	],
+	"raster": [
+	  "0.0*cm, 0.0*cm"
+	],
+	"beam_spot": [
+	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
+	],
+	"z-position": [
+	  "-6.0*cm, 1.0*cm"
+	],
+	"software_versions": [
+	  "gemc/dev coatjava/10.1.1"
+        ]
+  },
+  "rge_spring2024_LD2-Cu-liq": {
+	"tor-1.00_sol-1.00": [
+	],
+	"raster": [
+	  "0.0*cm, 0.0*cm"
+	],
+	"beam_spot": [
+	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
+	],
+	"z-position": [
+	  "-6.0*cm, 1.0*cm"
+	],
+	"software_versions": [
+	  "gemc/dev coatjava/10.1.1"
+        ]
+  },
+  "rge_spring2024_LD2-Sn-liq": {
+	"tor-1.00_sol-1.00": [
+	],
+	"raster": [
+	  "0.0*cm, 0.0*cm"
+	],
+	"beam_spot": [
+	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
+	],
+	"z-position": [
+	  "-6.0*cm, 1.0*cm"
+	],
+	"software_versions": [
+	  "gemc/dev coatjava/10.1.1"
+        ]
+  },
+  "rge_spring2024_LD2-Pb-liq": {
+	"tor-1.00_sol-1.00": [
+	],
+	"raster": [
+	  "0.0*cm, 0.0*cm"
+	],
+	"beam_spot": [
+	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
+	],
+	"z-position": [
+	  "-6.0*cm, 1.0*cm"
+	],
+	"software_versions": [
+	  "gemc/dev coatjava/10.1.1"
+        ]
   }
 }


### PR DESCRIPTION
Added 10 configurations for RGE to setup.json. Two configurations per each of the  five solid target positions, one for solid and other for liquid target vertex. Notice that for this configurations, the semi-length in solid target z-positions are written in mm.