### PR TITLE
RGE updated gemc gcards and setup.json

### DIFF
--- a/gemc/5.11/rge_spring2024_LD2-Al-sol.gcard
+++ b/gemc/5.11/rge_spring2024_LD2-Al-sol.gcard
@@ -78,7 +78,7 @@
 
 	<!--  Run Number 11, picked up by digitization routines -->
 	<option name="RUNNO"    value="11" />
-	<option name="DIGITIZATION_VARIATION"  value="rga_fall2018_mc" />
+	<option name="DIGITIZATION_VARIATION"  value="rge_spring2024_mc" />
 
 	<!--  Do not track staff after the apex -->
 	<option name="MAX_Z_POS" value="9000"/>
@@ -112,10 +112,8 @@
 <!-- torus magnet: 2cm-->
 	<option name="PRODUCTIONCUTFORVOLUMES" value="BoreShield, CenterTube, DownstreamShieldingPlate, DownstreamVacuumJacket, WarmBoreTube, apex, Shield1, Shield2, Shield3, Shield4, Shield5, Shield6, Shield7, shell1a, shell1b, shell2a, shell2b, shell3a, shell3b, shell4a, shell4b, shell5a, shell5b, shell6a, shell6b, 20" />
 
-	<!--  Target and central detectors are all shifted upstream by 30 mm -->
-	<detector name="target">    <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
+	<!--  Central detectors are all shifted upstream by 30 mm -->
 	<detector name="svt">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
-	<detector name="bstShield"> <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="BMT">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="FMT">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="ctof">      <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
@@ -129,5 +127,11 @@
 	<detector name="htcc">                 <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
 	<detector name="htccEntryWindow">      <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
 	<detector name="htccExitWindow">       <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
+
+	<!--  Target shifted upstream by 5 mm due to thermal contraction-->
+	<detector name="target">    <position x="0*cm"     y="0*cm"     z="-0.50*cm"  />  </detector>
+
+	<!--  BST shield shifted downstream by 15 mm to align to scattering chamber-->
+	<detector name="bstShield"> <position x="0*cm"     y="0*cm"     z="1.50*cm"  />  </detector>
 
 </gcard>

--- a/gemc/5.11/rge_spring2024_LD2-C-sol.gcard
+++ b/gemc/5.11/rge_spring2024_LD2-C-sol.gcard
@@ -78,7 +78,7 @@
 
 	<!--  Run Number 11, picked up by digitization routines -->
 	<option name="RUNNO"    value="11" />
-	<option name="DIGITIZATION_VARIATION"  value="rga_fall2018_mc" />
+	<option name="DIGITIZATION_VARIATION"  value="rge_spring2024_mc" />
 
 	<!--  Do not track staff after the apex -->
 	<option name="MAX_Z_POS" value="9000"/>
@@ -112,10 +112,8 @@
 <!-- torus magnet: 2cm-->
 	<option name="PRODUCTIONCUTFORVOLUMES" value="BoreShield, CenterTube, DownstreamShieldingPlate, DownstreamVacuumJacket, WarmBoreTube, apex, Shield1, Shield2, Shield3, Shield4, Shield5, Shield6, Shield7, shell1a, shell1b, shell2a, shell2b, shell3a, shell3b, shell4a, shell4b, shell5a, shell5b, shell6a, shell6b, 20" />
 
-	<!--  Target and central detectors are all shifted upstream by 30 mm -->
-	<detector name="target">    <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
+	<!--  Central detectors are all shifted upstream by 30 mm -->
 	<detector name="svt">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
-	<detector name="bstShield"> <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="BMT">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="FMT">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="ctof">      <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
@@ -129,5 +127,11 @@
 	<detector name="htcc">                 <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
 	<detector name="htccEntryWindow">      <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
 	<detector name="htccExitWindow">       <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
+
+	<!--  Target shifted upstream by 5 mm due to thermal contraction-->
+	<detector name="target">    <position x="0*cm"     y="0*cm"     z="-0.50*cm"  />  </detector>
+
+	<!--  BST shield shifted downstream by 15 mm to align to scattering chamber-->
+	<detector name="bstShield"> <position x="0*cm"     y="0*cm"     z="1.50*cm"  />  </detector>
 
 </gcard>

--- a/gemc/5.11/rge_spring2024_LD2-Cu-sol.gcard
+++ b/gemc/5.11/rge_spring2024_LD2-Cu-sol.gcard
@@ -78,7 +78,7 @@
 
 	<!--  Run Number 11, picked up by digitization routines -->
 	<option name="RUNNO"    value="11" />
-	<option name="DIGITIZATION_VARIATION"  value="rga_fall2018_mc" />
+	<option name="DIGITIZATION_VARIATION"  value="rge_spring2024_mc" />
 
 	<!--  Do not track staff after the apex -->
 	<option name="MAX_Z_POS" value="9000"/>
@@ -112,10 +112,8 @@
 <!-- torus magnet: 2cm-->
 	<option name="PRODUCTIONCUTFORVOLUMES" value="BoreShield, CenterTube, DownstreamShieldingPlate, DownstreamVacuumJacket, WarmBoreTube, apex, Shield1, Shield2, Shield3, Shield4, Shield5, Shield6, Shield7, shell1a, shell1b, shell2a, shell2b, shell3a, shell3b, shell4a, shell4b, shell5a, shell5b, shell6a, shell6b, 20" />
 
-	<!--  Target and central detectors are all shifted upstream by 30 mm -->
-	<detector name="target">    <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
+	<!--  Central detectors are all shifted upstream by 30 mm -->
 	<detector name="svt">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
-	<detector name="bstShield"> <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="BMT">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="FMT">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="ctof">      <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
@@ -129,5 +127,11 @@
 	<detector name="htcc">                 <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
 	<detector name="htccEntryWindow">      <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
 	<detector name="htccExitWindow">       <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
+
+	<!--  Target shifted upstream by 5 mm due to thermal contraction-->
+	<detector name="target">    <position x="0*cm"     y="0*cm"     z="-0.50*cm"  />  </detector>
+
+	<!--  BST shield shifted downstream by 15 mm to align to scattering chamber-->
+	<detector name="bstShield"> <position x="0*cm"     y="0*cm"     z="1.50*cm"  />  </detector>
 
 </gcard>

--- a/gemc/5.11/rge_spring2024_LD2-Pb-sol.gcard
+++ b/gemc/5.11/rge_spring2024_LD2-Pb-sol.gcard
@@ -78,7 +78,7 @@
 
 	<!--  Run Number 11, picked up by digitization routines -->
 	<option name="RUNNO"    value="11" />
-	<option name="DIGITIZATION_VARIATION"  value="rga_fall2018_mc" />
+	<option name="DIGITIZATION_VARIATION"  value="rge_spring2024_mc" />
 
 	<!--  Do not track staff after the apex -->
 	<option name="MAX_Z_POS" value="9000"/>
@@ -112,10 +112,8 @@
 <!-- torus magnet: 2cm-->
 	<option name="PRODUCTIONCUTFORVOLUMES" value="BoreShield, CenterTube, DownstreamShieldingPlate, DownstreamVacuumJacket, WarmBoreTube, apex, Shield1, Shield2, Shield3, Shield4, Shield5, Shield6, Shield7, shell1a, shell1b, shell2a, shell2b, shell3a, shell3b, shell4a, shell4b, shell5a, shell5b, shell6a, shell6b, 20" />
 
-	<!--  Target and central detectors are all shifted upstream by 30 mm -->
-	<detector name="target">    <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
+	<!--  Central detectors are all shifted upstream by 30 mm -->
 	<detector name="svt">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
-	<detector name="bstShield"> <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="BMT">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="FMT">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="ctof">      <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
@@ -129,5 +127,11 @@
 	<detector name="htcc">                 <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
 	<detector name="htccEntryWindow">      <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
 	<detector name="htccExitWindow">       <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
+
+	<!--  Target shifted upstream by 5 mm due to thermal contraction-->
+	<detector name="target">    <position x="0*cm"     y="0*cm"     z="-0.50*cm"  />  </detector>
+
+	<!--  BST shield shifted downstream by 15 mm to align to scattering chamber-->
+	<detector name="bstShield"> <position x="0*cm"     y="0*cm"     z="1.50*cm"  />  </detector>
 
 </gcard>

--- a/gemc/5.11/rge_spring2024_LD2-Sn-sol.gcard
+++ b/gemc/5.11/rge_spring2024_LD2-Sn-sol.gcard
@@ -78,7 +78,7 @@
 
 	<!--  Run Number 11, picked up by digitization routines -->
 	<option name="RUNNO"    value="11" />
-	<option name="DIGITIZATION_VARIATION"  value="rga_fall2018_mc" />
+	<option name="DIGITIZATION_VARIATION"  value="rge_spring2024_mc" />
 
 	<!--  Do not track staff after the apex -->
 	<option name="MAX_Z_POS" value="9000"/>
@@ -112,10 +112,8 @@
 <!-- torus magnet: 2cm-->
 	<option name="PRODUCTIONCUTFORVOLUMES" value="BoreShield, CenterTube, DownstreamShieldingPlate, DownstreamVacuumJacket, WarmBoreTube, apex, Shield1, Shield2, Shield3, Shield4, Shield5, Shield6, Shield7, shell1a, shell1b, shell2a, shell2b, shell3a, shell3b, shell4a, shell4b, shell5a, shell5b, shell6a, shell6b, 20" />
 
-	<!--  Target and central detectors are all shifted upstream by 30 mm -->
-	<detector name="target">    <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
+	<!--  Central detectors are all shifted upstream by 30 mm -->
 	<detector name="svt">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
-	<detector name="bstShield"> <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="BMT">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="FMT">       <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
 	<detector name="ctof">      <position x="0*cm"     y="0*cm"     z="-3.00*cm"  />  </detector>
@@ -129,5 +127,11 @@
 	<detector name="htcc">                 <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
 	<detector name="htccEntryWindow">      <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
 	<detector name="htccExitWindow">       <position x="0*cm"  y="0*cm"  z="-1.94*cm"  />  </detector>
+
+	<!--  Target shifted upstream by 5 mm due to thermal contraction-->
+	<detector name="target">    <position x="0*cm"     y="0*cm"     z="-0.50*cm"  />  </detector>
+
+	<!--  BST shield shifted downstream by 15 mm to align to scattering chamber-->
+	<detector name="bstShield"> <position x="0*cm"     y="0*cm"     z="1.50*cm"  />  </detector>
 
 </gcard>

--- a/setup.json
+++ b/setup.json
@@ -261,7 +261,7 @@
 	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
 	],
 	"z-position": [
-	  "-1.0*cm, 0.6*mm"
+	  "-1.5*cm, 0.6*mm"
 	],
 	"software_versions": [
 	  "gemc/5.11 coatjava/11.1.0"
@@ -277,7 +277,7 @@
 	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
 	],
 	"z-position": [
-	  "-1.0*cm, 0.74*mm"
+	  "-1.5*cm, 0.74*mm"
 	],
 	"software_versions": [
 	  "gemc/5.11 coatjava/11.1.0"
@@ -293,7 +293,7 @@
 	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
 	],
 	"z-position": [
-	  "-1.0*cm, 0.18*mm"
+	  "-1.5*cm, 0.18*mm"
 	],
 	"software_versions": [
 	  "gemc/5.11 coatjava/11.1.0"
@@ -309,7 +309,7 @@
 	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
 	],
 	"z-position": [
-	  "-1.0*cm, 0.15*mm"
+	  "-1.5*cm, 0.15*mm"
 	],
 	"software_versions": [
 	  "gemc/5.11 coatjava/11.1.0"
@@ -325,7 +325,7 @@
 	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
 	],
 	"z-position": [
-	  "-1.0*cm, 0.07*mm"
+	  "-1.5*cm, 0.07*mm"
 	],
 	"software_versions": [
 	  "gemc/5.11 coatjava/11.1.0"
@@ -341,7 +341,7 @@
 	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
 	],
 	"z-position": [
-	  "-6.0*cm, 1.0*cm"
+	  "-6.5*cm, 1.0*cm"
 	],
 	"software_versions": [
 	  "gemc/5.11 coatjava/11.1.0"
@@ -357,7 +357,7 @@
 	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
 	],
 	"z-position": [
-	  "-6.0*cm, 1.0*cm"
+	  "-6.5*cm, 1.0*cm"
 	],
 	"software_versions": [
 	  "gemc/5.11 coatjava/11.1.0"
@@ -373,7 +373,7 @@
 	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
 	],
 	"z-position": [
-	  "-6.0*cm, 1.0*cm"
+	  "-6.5*cm, 1.0*cm"
 	],
 	"software_versions": [
 	  "gemc/5.11 coatjava/11.1.0"
@@ -389,7 +389,7 @@
 	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
 	],
 	"z-position": [
-	  "-6.0*cm, 1.0*cm"
+	  "-6.5*cm, 1.0*cm"
 	],
 	"software_versions": [
 	  "gemc/5.11 coatjava/11.1.0"
@@ -405,7 +405,7 @@
 	  "0.0*mm, 0.0*mm, 0.0*mm, 0.0*mm, 0*deg"
 	],
 	"z-position": [
-	  "-6.0*cm, 1.0*cm"
+	  "-6.5*cm, 1.0*cm"
 	],
 	"software_versions": [
 	  "gemc/5.11 coatjava/11.1.0"


### PR DESCRIPTION
## Updated positions of target and BST shield in RGE gcards for gemc version 5.11.
There was a mistake in the position in both BST shield and target in RGE gcards.
The geometries of the RGE target already have in consideration the 30 mm shift downstream. In the gcards this shift was accounted again, positioning the target in the wrong place.
The BST shield was not properly aligned with the scattering chamber. The new position covers the scattering chamber correctly.
The new positions also account the thermal contraction of the target system, moving it 0.5 cm downstream from the default position, making it more comparable with the real experiment.
Finally for the gcards, the DIGITIZATION_VARIATION was changed from rga_fall2018_mc to rge_spring2024_mc

## Updated setup.json
The setup.json file was modified for RGE configurations to move the z-vertex from the default position to the new position accounting this 0.5 mm shift downstream due to thermal contraction.

## Images
### Before
RGE geometry before position correction, target is too far downstream. BST shield sticks out a few centimeters downstream.
![rge_before_correction](https://github.com/user-attachments/assets/63fd7126-01d5-42ad-a3ae-b7c154b7eebd)

### After
RGE geometry after position correction. BST shield covers the scattering chamber correctly.
![rge_after_correction](https://github.com/user-attachments/assets/22d34622-1067-4384-a43e-7d84e9dede9b)