### PR TITLE
fixer-upper:  mcdj

### DIFF
--- a/util/mcdj
+++ b/util/mcdj
@@ -82,15 +82,22 @@ def get_out(inp, prefix=None, suffix=None):
 
 # run a clas12-mcgen event genetator:
 def generate(cfg):
+    import time
     o = cfg.gen[0]+'.dat'
     cmd = [cfg.gen[0]]
-    cmd.extend(['--docker','--trig',str(cfg.n),'--seed',str(cfg.seed)])
+    seed = cfg.seed
+    if seed == 0:
+        # get a 32-bit RNG seed from system clock
+        cfg.seed = int(time.time()*1e6) & 0xFFFFFFFF
+    cmd.extend(['--docker','--trig',str(cfg.n),'--seed',str(seed)])
     cmd.extend(cfg.gen[1:])
     return run(cfg,cmd), o
 
 # run GEMC, with LUND input or internal generator:
 def gemc(cfg, lund=None):
     cmd = ['gemc',cfg.gcard,f'-RUNNO={cfg.run}','-USE_GUI=0',f'-N={cfg.n}']
+    if cfg.seed != 0:
+        cmd.extend([f'-RANDOM={cfg.seed}'])
     if cfg.match:
         cmd.extend(['-SAVE_ALL_MOTHERS=1','-SKIPREJECTEDHITS=1','-INTEGRATEDRAW="*"','-NGENP=50'])
     if lund:
@@ -218,6 +225,7 @@ def make_workdir(d):
     _logger.warning(f'using new working directory:  {d} ...')
     return d
 
+# configure the whole darn thing:
 def configure(args):
 
     # parse command-line:


### PR DESCRIPTION
* remove/disable unneeded/broken options
* add job parallelization option
* remove config file retrieval (we're already here now!)
* implement clock-based RNG seeding for generators
* cleanup documentation

```
clara2502> ./mcdj -h
usage: mcdj [-h] [-n #] [-j #] -g PATH -y PATH [-r RUN] [-m] [-b PATH] [-s SEED] [-d] [-q] [-v] [--denoise]
            gen [gen ...]

CLAS12 Monte-Carlo Deejay

positional arguments:
  gen               generator command line, or LUND file

options:
  -h, --help        show this help message and exit
  -n #              number of events (default=10)
  -j, --jobs #      number of parallel jobs (default=1)
  -g, --gcard PATH  GEMC gcard configuration file
  -y, --yaml PATH   COATJAVA yaml configuration file
  -r, --run RUN     run number (default=11)
  -m, --match       enable truth matching
  -b, --back PATH   background files for merging
  -s, --seed SEED   random number seed (default=clock)
  -d, --dst         run standalone dst-maker
  -q, --quiet       silence GEANT4 exceptions
  -v, --verbose     increase verbosity (repeatable)
  --denoise         enable *old* denoising (use YAML for new)

All executables must be in $PATH. Generator command-line options can be placed after a "--", e.g., if sharing
the same name as one of mcdj's. See https://github.com/jeffersonlab/clas12-config for configuration files.
```