### PR TITLE
mcdj: back to thread pool, no need for more processes

### DIFF
--- a/mcdj
+++ b/mcdj
@@ -256,7 +256,7 @@ def launch_pipelines(cfg):
     ijob,ojob = 0,0
     futures = []
     results = cfg.jobs * cfg.Jobs * [SimpleNamespace(stat=1, out=None, cwd=None)]
-    with cf.ProcessPoolExecutor(max_workers=cfg.jobs) as exe:
+    with cf.ThreadPoolExecutor(max_workers=cfg.jobs) as exe:
         while True:
             # collect finished tasks:
             for i,f in enumerate(futures):


### PR DESCRIPTION
It was already (and still) spawning subprocesses after all (doh).