### PR TITLE
mcdj:  remove unused numa function

### DIFF
--- a/mcdj
+++ b/mcdj
@@ -95,15 +95,6 @@ def run(cfg, cwd, cmd):
     p.wait()
     return p.returncode
 
-def get_numa_cpus(node):
-    import subprocess
-    cmd = ['numactl','-H']
-    logging.getLogger(__name__).info(' '.join(cmd))
-    p = subprocess.Popen(cmd,stdout=subprocess.PIPE,stderr=subprocess.STDOUT,universal_newlines=True,encoding='latin-1')
-    for line in iter(p.stdout.readline, ''):
-        if line.startswith(f'node {node} cpus:'):
-            return line.strip().split()[3:]
-
 # a list of all the output files we've made:
 _outputs = []
 


### PR DESCRIPTION
Not useful for these single-core processes.  It was added spuriously while investigating the cpu throttling on clara nodes.  